### PR TITLE
Refactor

### DIFF
--- a/gc.py
+++ b/gc.py
@@ -38,16 +38,22 @@ def dispose():
     os.chdir(Config.ROOT_DIR)
     p = Path(".")
     for child in p.iterdir():
-        if child.name == "static":
-            shutil.rmtree(child, ignore_errors=True)
-            logger.warning(f"Removed directory: {child}")
-        else:
+        if child.name != "static":
             stat = Path(child).stat()
             mod_time = pendulum.from_timestamp(stat.st_ctime)
             time_delta = now.diff(mod_time).in_minutes()
             if time_delta > Config.STALE:
                 shutil.rmtree(child, ignore_errors=True)
                 logger.warning(f"Removed directory: {child}")
+    p = Path("static")
+    for child in p.iterdir():
+        stat = Path(child).stat()
+        mod_time = pendulum.from_timestamp(stat.st_ctime)
+        time_delta = now.diff(mod_time).in_minutes()
+        if time_delta > Config.STALE:
+            Path(child).unlink(missing_ok=True)
+            logger.warning(f"Removed static file: {child}")
+
 
 
 def main():

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -5,6 +5,7 @@
 :Mod: __init__
 
 :Synopsis:
+    Initialize webapp, including working directories (see Config.ROOT_DIR).
 
 :Author:
     servilla

--- a/webapp/dex/dobject.py
+++ b/webapp/dex/dobject.py
@@ -12,11 +12,11 @@
 :Created:
     4/12/20
 """
-from pathlib import PurePath
-
-import pandas as pd
+from pathlib import Path, PurePath
+import pickle
 
 import daiquiri
+import pandas as pd
 
 
 logger = daiquiri.getLogger(__name__)
@@ -28,15 +28,37 @@ class Dobject:
         self._file_name = entity["file_name"]
         self._file_path = str(PurePath(self._file_spec).parent)
         self._purl = entity["purl"]
-        self._df = pd.read_csv(self._file_spec)
-        self._head = get_head(self._df)
-        self._keys = self._df.keys()
-        self._dtypes = self._df.dtypes.items()
-        self._shape = self._df.shape
-        self._stats = get_stats(self._df)
-        self._rows = self._shape[0]
-        self._cols = self._shape[1]
-        _ = PurePath(self._file_spec)
+        dobject_pkl = self._file_path + "/dobject.pkl"
+        if Path(dobject_pkl).exists():
+            with open(dobject_pkl, "rb") as f:
+                dobject_dict = pickle.load(f)
+            self._head = dobject_dict["head"]
+            self._keys = dobject_dict["keys"]
+            self._dtypes = dobject_dict["dtypes"]
+            self._shape = dobject_dict["shape"]
+            self._stats = dobject_dict["stats"]
+            self._rows = dobject_dict["rows"]
+            self._cols = dobject_dict["cols"]
+        else:
+            self._df = pd.read_csv(self._file_spec)
+            self._head = get_head(self._df)
+            self._keys = self._df.keys()
+            self._dtypes = self._df.dtypes.items()
+            self._shape = self._df.shape
+            self._stats = get_stats(self._df)
+            self._rows = self._shape[0]
+            self._cols = self._shape[1]
+            dobject_dict = {
+                "head": self._head,
+                "keys": self._keys,
+                "dtypes": self._dtypes,
+                "shape": self._shape,
+                "stats": self._stats,
+                "rows": self._rows,
+                "cols": self._cols
+            }
+            with open(dobject_pkl, "wb") as f:
+                pickle.dump(dobject_dict, f)
 
     @property
     def cols(self):
@@ -83,12 +105,14 @@ class Dobject:
         return self._stats
 
     def subset(self, columns: list, r_start: int, r_end: int):
-        df = self._df.iloc[r_start:r_end + 1, columns]
+        df = pd.read_csv(self._file_spec)
+        df = df.iloc[r_start:r_end + 1, columns]
         df.to_csv(self._file_path + "/subset.csv", index=False, header=True)
         return df
 
     def plot(self, columns: list, date_x: bool):
-        df = self._df.iloc[:, columns]
+        df = pd.read_csv(self._file_spec)
+        df = df.iloc[:, columns]
         if date_x:
             df[df.keys()[0]] = pd.to_datetime(df[df.keys()[0]])
         return df

--- a/webapp/dex/dplot.py
+++ b/webapp/dex/dplot.py
@@ -12,20 +12,15 @@
 :Created:
     4/21/20
 """
-import os
-
 from bokeh.plotting import figure, output_file, save, show
 from bokeh.models import ColumnDataSource
 import daiquiri
-
-from webapp.config import Config
 
 
 logger = daiquiri.getLogger(__name__)
 
 
 def plot_xy(df, date_x: bool, file_spec: str):
-    os.makedirs(Config.ROOT_DIR + "/static", exist_ok=True)
     output_file(file_spec)
     if date_x:
         p = figure(x_axis_type='datetime')

--- a/webapp/templates/plot.html
+++ b/webapp/templates/plot.html
@@ -12,7 +12,7 @@
     {% endwith %}
 
     {% block app_content %}
-            <iframe src="{{ url_for("static", filename=f) }}" style="height:660px;width:660px;"></iframe>
+            <iframe src="{{ url_for("static", filename=f) }}" style="height:630px;width:630px;"></iframe>
     {%  endblock app_content %}
 
 </div>

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -44,13 +44,6 @@ app.config.from_object(Config)
 bootstrap = Bootstrap(app)
 
 
-@app.route("/clean")
-def clean():
-    file_spec = session.get("key")
-    datatable.remove(file_spec)
-    return "None"
-
-
 @app.route("/info")
 def info():
     key = session["key"]


### PR DESCRIPTION
Critical changes include the following:

1. Garbage collection in gc.py now does not blindly remove the entire directory, but rather, applies the same stale TTL logic to each generated bokeh html file.
2. The data object class "dobject" now only loads the panda data frame when necessary, including the first time when explorer the data table; all key (and more importantly, small volume) attributes are stored in a pickle so that subsequent calls to the dobject object does not result in painfully slow data frame loads. At present, the only two calls (other than the initial load) that requires loading a data frame are (1) subsetting and (2) plotting.